### PR TITLE
ci-cd: rename release to deploy

### DIFF
--- a/azure-pipelines/cd.yaml
+++ b/azure-pipelines/cd.yaml
@@ -4,7 +4,7 @@ name: $(BuildID)
 trigger:
   branches:
     include:
-    - release
+    - deploy
   paths:
     exclude:
     - '*.md'

--- a/azure-pipelines/detect-drift.yaml
+++ b/azure-pipelines/detect-drift.yaml
@@ -10,7 +10,7 @@ trigger:
     - main
 
 pr:
-- release
+- deploy
 
 schedules:
   - cron: "0 0 * * *"


### PR DESCRIPTION
- Changing pipeline triggers from `release` to better descriptive `deploy` because this is not a software release. 
- We are using it as a deployment trigger.