### PR TITLE
fix(pipeline): load kv based on branch in scheduled drift detection

### DIFF
--- a/azure-pipelines/cd.yaml
+++ b/azure-pipelines/cd.yaml
@@ -19,19 +19,16 @@ pool:
 
 variables:
 - template: vars/global.yaml
+- ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+  - group: e2e-gov-demo-dev-kv
+- ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/production') }}:
+  - group: e2e-gov-demo-kv
 
 stages:
 - template: stages/ci.yaml
 
 - stage: cd_stage
-  displayName: CD Stage
-
-  variables:
-  - ${{ if eq(variables.isMain, 'True') }}:
-    - group: e2e-gov-demo-dev-kv
-  - ${{ if eq(variables.isProduction, 'True') }}:
-    - group: e2e-gov-demo-kv
-
+  displayName: CD - Deployment
   jobs:
   - job: deploy
     displayName: Terraform Plan and Apply

--- a/azure-pipelines/schedule-drift.yaml
+++ b/azure-pipelines/schedule-drift.yaml
@@ -17,9 +17,9 @@ schedules:
 
 variables:
 - template: vars/global.yaml
-- ${{ if eq(variables.isMain, 'True') }}:
+- ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
   - group: e2e-gov-demo-dev-kv
-- ${{ if eq(variables.isProduction, 'True') }}:
+- ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/production') }}:
   - group: e2e-gov-demo-kv
 
 steps:

--- a/azure-pipelines/stages/ci.yaml
+++ b/azure-pipelines/stages/ci.yaml
@@ -1,6 +1,6 @@
 stages:
 - stage: CIStage
-  displayName: CI
+  displayName: CI - Integration
   jobs:
   - job: CIJob
     displayName: Terraform - Lint and Validate

--- a/azure-pipelines/steps/confirm-kv-loaded.yaml
+++ b/azure-pipelines/steps/confirm-kv-loaded.yaml
@@ -1,18 +1,19 @@
 steps:
 - bash: |
     echo ""
-    echo ""
-
-    echo "***** Confirm Key Vault Integration *****"
-    echo "Fail pipeline if no key vault is loaded before Terraform tries and fails."
+    echo "--------------------------------"
+    echo "Confirm Key Vault 🔑 Integration"
+    echo "--------------------------------"
     echo "KV_DEBUG_ENV: $KV_DEBUG_ENV"
     echo ""
     if [ "$KV_DEBUG_ENV" = '$(kv-debug-env)' ]; then
-      echo "Key Vault not loaded. If loaded properly, debug env value would be 'dev' or 'production'."
+      echo "⛔️ Key Vault not loaded"
+      echo "Please double check configuration Variable Groups in Azure Pipelines UI and that the YAML pipeline is running against the `main` or `production` branch."
       exit 1
     else
-      echo "Key Vault loaded for: $KV_DEBUG_ENV"
+      echo "✅ Key Vault loaded"
     fi
   displayName: Debug - Key Vault loaded?
   env:
     KV_DEBUG_ENV: $(kv-debug-env)
+

--- a/azure-pipelines/steps/debug-vars.yaml
+++ b/azure-pipelines/steps/debug-vars.yaml
@@ -1,5 +1,9 @@
 steps:
 - bash: |
+    echo ""
+    echo "---------"
+    echo "Debugging"
+    echo "---------"
     echo  "isMain: ${{ variables.isMain }}"
     echo  "isProduction: ${{ variables.isProduction }}"
     echo  "Build.SourceBranch: ${{ variables['Build.SourceBranch'] }}"


### PR DESCRIPTION
## Problem

Scheduled Drift Detection Builds were failing because the key vaults with the credentials were not being loaded. 

Error Message

```
***** Confirm Key Vault Integration *****
Fail pipeline if no key vault is loaded before Terraform tries and fails.
KV_DEBUG_ENV: $(kv-debug-env)

Key Vault not loaded. If loaded properly, debug env value would be 'dev' or 'production'.
##[error]Bash exited with code '1'.
```

## Cause

The `- template: vars/global.yaml` is loaded but its values, e.g. `variables.isMain` do not seem to be _immediately_ available in the same global `variables:` scope.

## Solution

Use Built-In variables instead of my preferred cleaner version:

```yaml
variables:
- template: vars/global.yaml
- ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
  - group: e2e-gov-demo-dev-kv
- ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/production') }}:
  - group: e2e-gov-demo-kv
 ```