### PR TITLE
fix(pipelines): var group conditional must use compile time syntax

### DIFF
--- a/azure-pipelines/cd.yaml
+++ b/azure-pipelines/cd.yaml
@@ -19,9 +19,13 @@ pool:
 
 variables:
 - template: vars/global.yaml
-- ${{ if eq(variables.isMain, 'True') }}:
+
+# Conditional uses ${{ }} syntax in order to be processed at compile time
+# in order to work for loading variable groups. For details see:
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#understand-variable-syntax
+- ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
   - group: e2e-gov-demo-dev-kv
-- ${{ if eq(variables.isProduction, 'True') }}:
+- ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/production') }}:
   - group: e2e-gov-demo-kv
 
 stages:


### PR DESCRIPTION
Not 100% sure why this doesn't work

```yaml
variables:
- template: vars/global.yaml
- ${{ if eq(variables.isMain, 'True') }}:
  - group: e2e-gov-demo-dev-kv
- ${{ if eq(variables.isProduction, 'True') }}:
  - group: e2e-gov-demo-kv
```

but my guess is that `variables.isMain` etc. isn't immediately available because they are defined in `vars/global.yaml` and may not be able at compile time in the next line of code. Switching back to `variables['Build.SourceBranch']` which is a [predefined system variable](https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml) and available from beginning.

So hoping this syntax works:

```
- ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
  - group: e2e-gov-demo-dev-kv
```

