### PR TITLE
Add owners to AAD applications

### DIFF
--- a/azure-pipelines/cd.yaml
+++ b/azure-pipelines/cd.yaml
@@ -19,6 +19,7 @@ pool:
 
 variables:
 - template: vars/global.yaml
+- group: mask-ids
 
 # Conditional uses ${{ }} syntax in order to be processed at compile time
 # in order to work for loading variable groups. For details see:

--- a/azure-pipelines/pr-main.yaml
+++ b/azure-pipelines/pr-main.yaml
@@ -11,6 +11,7 @@ pr:
 variables:
   - template: vars/global.yaml
   - group: e2e-gov-demo-dev-kv # DEV
+  - group: mask-ids
 
 stages:
   - template: stages/ci.yaml

--- a/azure-pipelines/pr-production.yaml
+++ b/azure-pipelines/pr-production.yaml
@@ -11,6 +11,7 @@ pr:
 variables:
   - template: vars/global.yaml
   - group: e2e-gov-demo-kv # PROD
+  - group: mask-ids
 
 stages:
   - template: stages/ci.yaml

--- a/main.tf
+++ b/main.tf
@@ -13,10 +13,9 @@ resource "random_string" "suffix" {
 }
 
 locals {
-  suffix = random_string.suffix.result
-
-  # Default to current ARM client
-  superadmins_aad_object_id = var.superadmins_aad_object_id == "" ? data.azurerm_client_config.current.object_id : var.superadmins_aad_object_id
+  suffix                    = random_string.suffix.result
+  application_owners_ids    = length(var.application_owners_ids) == 0 ? [data.azurerm_client_config.current.object_id] : var.application_owners_ids
+  superadmins_aad_object_id = var.superadmins_aad_object_id == "" ? data.azurerm_client_config.current.object_id : var.superadmins_aad_object_id # Default to current ARM client
 }
 
 # ---------------
@@ -40,6 +39,7 @@ module "service_principals" {
   for_each = var.environments
   source   = "./modules/service-principal"
   name     = "${each.value.team}-${each.value.env}-${local.suffix}-ci-sp"
+  owners   = local.application_owners_ids
 }
 
 # ------------------------------

--- a/modules/service-principal/main.tf
+++ b/modules/service-principal/main.tf
@@ -4,6 +4,7 @@
 
 resource "azuread_application" "app" {
   display_name = local.name
+  owners       = var.owners
 }
 
 resource "azuread_application_password" "workspace_sp_secret" {

--- a/modules/service-principal/variables.tf
+++ b/modules/service-principal/variables.tf
@@ -23,6 +23,15 @@ variable "password_lifetime" {
   default     = "4380h"
 }
 
+variable "owners" {
+  type        = list(string)
+  description = "A set of object IDs of principals that will be granted ownership of the application (service principal)."
+  validation {
+    condition     = length(var.owners) > 0
+    error_message = "Every Application must have an owner. Owners cannot be empty."
+  }
+}
+
 # Normalize Values
 # ----------------
 

--- a/variables.tf
+++ b/variables.tf
@@ -5,6 +5,12 @@ variable "superadmins_aad_object_id" {
   default     = ""
 }
 
+variable "application_owners_ids" {
+  type        = list(string)
+  description = "A set of object IDs of principals that will be granted ownership of the application (service principal). Supported object types are users or service principals. It is best practice to specify one or more owners, incl. the principal used to execute Terraform"
+  default     = []
+}
+
 # AAD Groups
 variable "groups" {
   type = map(string)


### PR DESCRIPTION
Add application owners per [Best Practice in Terraform Doc](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application)

> Ownership of Applications
> It's recommended to always specify one or more application owners, including the principal being used to execute Terraform, such as in the example above.

See #49 for more